### PR TITLE
No credentials provided error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ HOSTNAME=fortanix.com
 NAMESPACE=fyoo
 NAME=dsm
 BINARY=terraform-provider-${NAME}
-VERSION=0.5.8
+VERSION=0.5.9
 OS_ARCH=darwin_arm64
 
 default: install

--- a/dsm/api_client.go
+++ b/dsm/api_client.go
@@ -100,8 +100,10 @@ func NewAPIClient(endpoint string, port int, username string, password string, a
 		authtype = "Basic "
 		authtoken = api_key
 		req.Header.Add("Authorization", authtype+authtoken)
-	} else {
+	} else if len(username) > 0 && len(password) > 0 {
 		req.SetBasicAuth(username, password)
+	} else {
+		return nil, fmt.Errorf("Unauthorized Access to DSM")
 	}
 
 	r, err := client.Do(req)


### PR DESCRIPTION
We accept two forms of authentication via TF
1. Username/password
2. API Key

If neither is not provided the error is not handled correctly.