### PR TITLE
[M] v0.5.14: adding support to use local proxy env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ HOSTNAME=fortanix.com
 NAMESPACE=fortanix
 NAME=dsm
 BINARY=terraform-provider-${NAME}
-VERSION=0.5.13
+VERSION=0.5.14
 OS_ARCH=darwin_arm64
 
 default: install

--- a/dsm/api_client.go
+++ b/dsm/api_client.go
@@ -79,6 +79,7 @@ func NewAPIClient(endpoint string, port int, username string, password string, a
 	// FIXME: clunky way of creating api_client session
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	rl := rate.NewLimiter(rate.Every(1*time.Second), 5) // 5 requests in every second


### PR DESCRIPTION
Adding proxy support in the API Client from env var; GoLang should be using this by default as per the 'http' doc, but it doesn't until we add this into the transport construct.