### PR TITLE
fyoo/csr generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ terraform.tfstate.backup
 .terraform.lock.hcl
 bin
 *.tf
+terraform-provider-dsm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM --platform=linux/amd64 hashicorp/terraform:latest
+ARG FX_TF_VERSION
+
+ENV FX_TF_VERSION=$FX_TF_VERSION
+RUN mkdir -p /root/.terraform.d/plugins/fortanix.com/fortanix/dsm/${FX_TF_VERSION}/linux_amd64
+COPY terraform-provider-dsm /root/.terraform.d/plugins/fortanix.com/fortanix/dsm/${FX_TF_VERSION}/linux_amd64
+RUN chmod +x /root/.terraform.d/plugins/fortanix.com/fortanix/dsm/${FX_TF_VERSION}/linux_amd64/terraform-provider-dsm

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ HOSTNAME=fortanix.com
 NAMESPACE=fortanix
 NAME=dsm
 BINARY=terraform-provider-${NAME}
-VERSION=0.5.14
-OS_ARCH=darwin_arm64
+VERSION=0.5.15
+OS_ARCH=linux_amd64
 
 default: install
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ HOSTNAME=fortanix.com
 NAMESPACE=fortanix
 NAME=dsm
 BINARY=terraform-provider-${NAME}
-VERSION=0.5.15
+VERSION=0.5.15-anz-dev-6
 OS_ARCH=linux_amd64
 
 default: install

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ HOSTNAME=fortanix.com
 NAMESPACE=fortanix
 NAME=dsm
 BINARY=terraform-provider-${NAME}
-VERSION=0.5.15-anz-dev-6
-OS_ARCH=linux_amd64
+VERSION=0.5.15
+OS_ARCH=darwin_arm64
 
 default: install
 

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,20 @@ NAMESPACE=fortanix
 NAME=dsm
 BINARY=terraform-provider-${NAME}
 VERSION=0.5.15
-OS_ARCH=darwin_arm64
+OS=linux
+ARCH=amd64
+OS_ARCH=${OS}_${ARCH}
 
-default: install
+default: build
 
 fmt: 
 	gofmt -w $(GOFMT_FILES)
 
 build:
-	CGO_ENABLED=0 go build -o ${BINARY}
+	CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -o ${BINARY}
+
+podman: build
+	podman build --build-arg FX_TF_VERSION=${VERSION} -t fortanix/fx-tf-test-image:${VERSION} .
 
 release:
 	mkdir -p ./bin/${VERSION}

--- a/docs/data-sources/dsm_csrs.md
+++ b/docs/data-sources/dsm_csrs.md
@@ -1,0 +1,34 @@
+# dsm\_csrs
+
+## dsm\_csrs
+
+Returns the Fortanix DSM cert sobject object details from the cluster as a Data Source.
+
+## Usage Reference
+
+```
+data "dsm_cert" "group" {
+    kid = <>
+    cn = <>
+}
+```
+
+## Argument Reference
+
+The following arguments are supported in the `dsm_cert` resource block:
+
+* _**kid**_ : Sobject key id value
+* _**cn**_ : Certificate Common Name
+
+## Attribute Reference
+
+The following attributes are stored in the `dsm_cert` data source block:
+
+* _**kid**_ : The security object kid
+* _**value**_ : The security object value of Generated CSR
+* _**ou**_ : The security object cert Organisational Unit
+* _**o**_ : The security object cert Organisation
+* _**l**_ : The security object cert Location
+* _**c**_ : The security object cert Country
+* _**cn**_: The security object cert Common Name
+* _**id**_: The unique ID of object from Terraform

--- a/docs/resources/dsm_csrs.md
+++ b/docs/resources/dsm_csrs.md
@@ -1,0 +1,33 @@
+# dsm\_certs
+
+## dsm\_certs
+
+Returns the Fortanix DSM cert security object certs from the cluster as a Resource.
+
+## Usage Reference
+
+```
+resource "dsm_csrs" "sobject" {
+    kid   = <sobject_id>
+    o     = <Company Name for Cert>
+    l     = <Location for Cert>
+    email = <Email for Cert>    
+}
+```
+
+## Argument Reference
+
+The following arguments are supported in the `dsm_csrs` resource block:
+
+* _**kid**_ : The security object kid
+* _**value**_ : The security object value of Generated CSR
+* _**ou**_ : The security object cert Organisational Unit
+* _**o**_ : The security object cert Organisation
+* _**l**_ : The security object cert Location
+* _**c**_ : The security object cert Country
+* _**st**_ :  The security object cert State
+* _**email**_ : Email value for cert
+* _**cn**_: The security object cert Common Name
+* _**dnsnames**_: The security object cert DNS Names
+* _**ips**_: The security object cert IPs
+* _**id**_: The unique ID of object from Terraform

--- a/dsm/api_client.go
+++ b/dsm/api_client.go
@@ -79,6 +79,7 @@ func NewAPIClient(endpoint string, port int, username string, password string, a
 	// FIXME: clunky way of creating api_client session
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	rl := rate.NewLimiter(rate.Every(1*time.Second), 5) // 5 requests in every second
@@ -222,6 +223,7 @@ func (obj *api_client) APICallBody(method string, url string, body map[string]in
 	var diags diag.Diagnostics
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: obj.insecure},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	rl := rate.NewLimiter(rate.Every(1*time.Second), 5) // 5 requests in every second
@@ -304,6 +306,7 @@ func (obj *api_client) APICall(method string, url string) (map[string]interface{
 	var diags diag.Diagnostics
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: obj.insecure},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	rl := rate.NewLimiter(rate.Every(1*time.Second), 5) // 5 requests in every second
@@ -393,6 +396,7 @@ func (obj *api_client) APICallList(method string, url string) ([]interface{}, di
 	var diags diag.Diagnostics
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: obj.insecure},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	rl := rate.NewLimiter(rate.Every(1*time.Second), 5) // 5 requests in every second
@@ -447,6 +451,7 @@ func (obj *api_client) FindPluginId(plugin_name string) ([]byte, diag.Diagnostic
 	var diags diag.Diagnostics
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: obj.insecure},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	rl := rate.NewLimiter(rate.Every(1*time.Second), 5) // 5 requests in every second

--- a/dsm/data_source_csr.go
+++ b/dsm/data_source_csr.go
@@ -1,0 +1,127 @@
+// **********
+// Terraform Provider - DSM: data source: csr
+// **********
+//       - Author:    fyoo at fortanix dot com
+//       - Version:   0.5.15
+//       - Date:      26/05/2022
+// **********
+
+package dsm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceCsr() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCsrRead,
+		Schema: map[string]*schema.Schema{
+			"kid": {
+				Type:      schema.TypeString,
+				Required:  true,
+			},
+			"value": {
+				Type:      schema.TypeString,
+				Computed:  true,
+			},
+			"ou": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "",
+			},
+			"o": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "",
+			},
+			"l": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "",
+			},
+			"c": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "",
+			},
+			"cn": {
+				Type:      schema.TypeString,
+				Required:  true,
+			},
+			"id": {
+				Type:      schema.TypeString,
+				Computed:  true,
+			},
+		},
+	}
+}
+
+func dataSourceCsrRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	subject_dn := make(map[string]interface{})
+
+	if cn := d.Get("cn").(string); len(cn) > 0 {
+		subject_dn["CN"] = cn
+	}
+
+	if ou := d.Get("ou").(string); len(ou) > 0 {
+		subject_dn["OU"] = ou
+	}
+
+	if l := d.Get("l").(string); len(l) > 0 {
+		subject_dn["L"] = l
+	}
+
+	if c := d.Get("c").(string); len(c) > 0 {
+		subject_dn["C"] = c
+	}
+
+	if o := d.Get("o").(string); len(o) > 0 {
+		subject_dn["O"] = o
+	}
+
+	plugin_object := map[string]interface{}{
+		"subject_key": d.Get("kid").(string),
+		"subject_dn": subject_dn,
+	}
+
+	reqfpi, err := m.(*api_client).FindPluginId("Terraform Plugin - CSR")
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "[DSM SDK] Unable to call DSM provider API client",
+			Detail:   fmt.Sprintf("[E]: API: GET sys/v1/plugins: %v", err),
+		})
+		return diags
+	}
+	var endpoint = fmt.Sprintf("sys/v1/plugins/%s", string(reqfpi))
+	var operation = "POST"
+
+	req, err := m.(*api_client).APICallBody(operation, endpoint, plugin_object)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "[DSM SDK] Unable to call DSM provider API client",
+			Detail:   fmt.Sprintf("[E]: API: POST sys/v1/plugins: %v", err),
+		})
+		return diags
+	}
+
+	if err := d.Set("kid", req["kid"].(string)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("id", req["id"].(string)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("value", req["value"].(string)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("id").(string))
+	return nil
+}

--- a/dsm/data_source_group_test.go
+++ b/dsm/data_source_group_test.go
@@ -3,8 +3,8 @@
 package dsm
 
 import (
-	"testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
 )
 
 var (

--- a/dsm/provider.go
+++ b/dsm/provider.go
@@ -91,6 +91,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"dsm_aws_group":   dataSourceAWSGroup(),
 			"dsm_azure_group": dataSourceAzureGroup(),
+			"dsm_csr":         dataSourceCsr(),
 			"dsm_secret":      dataSourceSecret(),
 			"dsm_group":       dataSourceGroup(),
 			"dsm_version":     dataSourceVersion(),

--- a/dsm/provider.go
+++ b/dsm/provider.go
@@ -86,12 +86,12 @@ func Provider() *schema.Provider {
 			"dsm_secret":        resourceSecret(),
 			"dsm_group":         resourceGroup(),
 			"dsm_app":           resourceApp(),
+			"dsm_csr":           resourceCsr(),
 			"dsm_gcp_ekm_sa":    resourceGcpEkmSa(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"dsm_aws_group":   dataSourceAWSGroup(),
 			"dsm_azure_group": dataSourceAzureGroup(),
-			"dsm_csr":         dataSourceCsr(),
 			"dsm_secret":      dataSourceSecret(),
 			"dsm_group":       dataSourceGroup(),
 			"dsm_version":     dataSourceVersion(),

--- a/dsm/provider_test.go
+++ b/dsm/provider_test.go
@@ -1,9 +1,9 @@
 package dsm
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"os"
 	"testing"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const (

--- a/dsm/resource_csr.go
+++ b/dsm/resource_csr.go
@@ -11,6 +11,7 @@ package dsm
 import (
 	"context"
 	"fmt"
+	"math/rand"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -52,6 +53,21 @@ func resourceCsr() *schema.Resource {
 				Optional: true,
 				Default:  "",
 			},
+			"st": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"san": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
 			"cn": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -71,67 +87,34 @@ func resourceCsr() *schema.Resource {
 func resourceCreateCsr(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	subject_dn := make(map[string]interface{})
-
-	if cn := d.Get("cn").(string); len(cn) > 0 {
-		subject_dn["CN"] = cn
-	}
-
-	if ou := d.Get("ou").(string); len(ou) > 0 {
-		subject_dn["OU"] = ou
-	}
-
-	if l := d.Get("l").(string); len(l) > 0 {
-		subject_dn["L"] = l
-	}
-
-	if c := d.Get("c").(string); len(c) > 0 {
-		subject_dn["C"] = c
-	}
-
-	if o := d.Get("o").(string); len(o) > 0 {
-		subject_dn["O"] = o
-	}
-
-	plugin_object := map[string]interface{}{
-		"subject_key": d.Get("kid").(string),
-		"subject_dn":  subject_dn,
-	}
-
-	reqfpi, err := m.(*api_client).FindPluginId("Terraform Plugin - CSR")
+	newsigner, err := NewDSMSigner(d.Get("kid").(string), d.Get("san").(string), d.Get("email").(string), d.Get("cn").(string), d.Get("ou").(string), d.Get("l").(string), d.Get("c").(string), d.Get("o").(string), d.Get("st").(string), m.(*api_client))
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "[DSM SDK] Unable to call DSM provider API client",
-			Detail:   fmt.Sprintf("[E]: API: GET sys/v1/plugins: %v", err),
-		})
-		return diags
-	}
-	var endpoint = fmt.Sprintf("sys/v1/plugins/%s", string(reqfpi))
-	var operation = "POST"
-
-	req, err := m.(*api_client).APICallBody(operation, endpoint, plugin_object)
-	if err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "[DSM SDK] Unable to call DSM provider API client",
-			Detail:   fmt.Sprintf("[E]: API: POST sys/v1/plugins: %v", err),
+			Summary:  "[DSM SDK] Unable to create signer",
+			Detail:   fmt.Sprintf("[E]: SDK: Terraform: %s", newsigner),
 		})
 		return diags
 	}
 
-	if err := d.Set("kid", req["kid"].(string)); err != nil {
-		return diag.FromErr(err)
+	generated_csr, err := newsigner.generate_csr()
+
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "[DSM SDK] Unable to get DSM signer up",
+			Detail:   fmt.Sprintf("[E]: SDK: Terraform: %s", err),
+		})
+		return diags
 	}
-	if err := d.Set("id", req["id"].(string)); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("value", req["value"].(string)); err != nil {
+
+	if err := d.Set("value", generated_csr); err != nil {
 		return diag.FromErr(err)
 	}
 
-	d.SetId(d.Get("id").(string))
-	return resourceReadCsr(ctx, d, m)
+	idSet := rand.Intn(99999999)
+	d.SetId(fmt.Sprintf("%s", idSet))
+	return nil
 }
 
 // [R]: Read Security Object

--- a/dsm/resource_csr.go
+++ b/dsm/resource_csr.go
@@ -1,5 +1,5 @@
 // **********
-// Terraform Provider - DSM: data source: csr
+// Terraform Provider - DSM: resource: csr
 // **********
 //       - Author:    fyoo at fortanix dot com
 //       - Version:   0.5.15
@@ -16,9 +16,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceCsr() *schema.Resource {
+// [-] Define Security Object
+func resourceCsr() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceCsrRead,
+		CreateContext: resourceCreateCsr,
+		ReadContext:   resourceReadCsr,
+		UpdateContext: resourceUpdateCsr,
+		DeleteContext: resourceDeleteCsr,
 		Schema: map[string]*schema.Schema{
 			"kid": {
 				Type:     schema.TypeString,
@@ -57,10 +61,14 @@ func dataSourceCsr() *schema.Resource {
 				Computed: true,
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 
-func dataSourceCsrRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+// [C]: Create CSR
+func resourceCreateCsr(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	subject_dn := make(map[string]interface{})
@@ -123,5 +131,21 @@ func dataSourceCsrRead(ctx context.Context, d *schema.ResourceData, m interface{
 	}
 
 	d.SetId(d.Get("id").(string))
+	return resourceReadCsr(ctx, d, m)
+}
+
+// [R]: Read Security Object
+func resourceReadCsr(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return nil
+}
+
+// [U]: Update Security Object
+func resourceUpdateCsr(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return nil
+}
+
+// [D]: Delete Security Object
+func resourceDeleteCsr(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.SetId("")
 	return nil
 }

--- a/dsm/resource_gcp_ekm_sa_test.go
+++ b/dsm/resource_gcp_ekm_sa_test.go
@@ -4,10 +4,10 @@ package dsm
 
 import (
 	"fmt"
-	"os"
-	"testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"os"
+	"testing"
 )
 
 var (

--- a/dsm/resource_group_test.go
+++ b/dsm/resource_group_test.go
@@ -3,9 +3,9 @@
 package dsm
 
 import (
-	"testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"testing"
 )
 
 var (

--- a/dsm/resource_sobject.go
+++ b/dsm/resource_sobject.go
@@ -108,6 +108,7 @@ func resourceSobject() *schema.Resource {
 			"custom_metadata": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -119,6 +120,7 @@ func resourceSobject() *schema.Resource {
 			"key_ops": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -131,10 +133,12 @@ func resourceSobject() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"expiry_date": {
 				Type:     schema.TypeString,
@@ -268,6 +272,11 @@ func resourceReadSobject(ctx context.Context, d *schema.ResourceData, m interfac
 		//if err := d.Set("links", req["links"]); err != nil {
 		//	return diag.FromErr(err)
 		//}
+		// FYOO: Fix this later - some wierd reaction to TypeList/TypeMap within TF
+		if err := d.Set("copied_to", req["copied_to"]); err != nil {
+			return diag.FromErr(err)
+		}
+
 		if _, ok := req["links"]; ok {
 			if links := req["links"].(map[string]interface{}); len(links) > 0 {
 				if _, copiedToExists := req["links"].(map[string]interface{})["copiedTo"]; copiedToExists {

--- a/dsm/resource_sobject.go
+++ b/dsm/resource_sobject.go
@@ -408,14 +408,14 @@ func resourceUpdateSobject(ctx context.Context, d *schema.ResourceData, m interf
 		security_object["key_ops"] = d.Get("key_ops")
 
 		req, err := m.(*api_client).APICallBody("PATCH", fmt.Sprintf("crypto/v1/keys/%s", d.Id()), security_object)
-			if err != nil {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Error,
-					Summary:  "[DSM SDK] Unable to call DSM provider API client",
-					Detail:   fmt.Sprintf("[E]: API: PATCH crypto/v1/keys: %v", err),
-				})
-				return diags
-			}
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "[DSM SDK] Unable to call DSM provider API client",
+				Detail:   fmt.Sprintf("[E]: API: PATCH crypto/v1/keys: %v", err),
+			})
+			return diags
+		}
 
 		key_ops := make([]string, len(req["key_ops"].([]interface{})))
 		if err := d.Get("key_ops").([]interface{}); len(err) > 0 {

--- a/dsm/resource_sobject.go
+++ b/dsm/resource_sobject.go
@@ -152,6 +152,17 @@ func resourceSobject() *schema.Resource {
 }
 
 // [-]: Custom Functions
+// contains: Need to validate whether a string exists in a []string
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}
+
 // createSO: Create Security Object
 func createSO(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
@@ -309,7 +320,32 @@ func resourceReadSobject(ctx context.Context, d *schema.ResourceData, m interfac
 				return diag.FromErr(err)
 			}
 		}
-		if err := d.Set("key_ops", req["key_ops"]); err != nil {
+		// FYOO: Fix TypeList sorting error
+		key_ops := make([]string, len(req["key_ops"].([]interface{})))
+		if err := d.Get("key_ops").([]interface{}); len(err) > 0 {
+			if len(d.Get("key_ops").([]interface{})) == len(req["key_ops"].([]interface{})) {
+				for idx, key_op := range d.Get("key_ops").([]interface{}) {
+					key_ops[idx] = fmt.Sprint(key_op)
+				}
+			} else {
+				req_key_ops := make([]string, len(req["key_ops"].([]interface{})))
+				for idx, key_op := range req["key_ops"].([]interface{}) {
+					req_key_ops[idx] = fmt.Sprint(key_op)
+				}
+				final_idx := 0
+				for _, key_op := range d.Get("key_ops").([]interface{}) {
+					if contains(req_key_ops, fmt.Sprint(key_op)) {
+						key_ops[final_idx] = fmt.Sprint(key_op)
+						final_idx = final_idx + 1
+					}
+				}
+			}
+		} else {
+			for idx, key_op := range req["key_ops"].([]interface{}) {
+				key_ops[idx] = fmt.Sprint(key_op)
+			}
+		}
+		if err := d.Set("key_ops", key_ops); err != nil {
 			return diag.FromErr(err)
 		}
 		if _, ok := req["description"]; ok {
@@ -355,6 +391,8 @@ func resourceReadSobject(ctx context.Context, d *schema.ResourceData, m interfac
 
 // [U]: Terraform Func: resourceUpdateSobject
 func resourceUpdateSobject(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	// already has been replaced so "rotate" and "rotate_from" does not apply
 	_, replacement := d.GetOkExists("replacement")
 	_, replaced := d.GetOkExists("replaced")
@@ -362,6 +400,47 @@ func resourceUpdateSobject(ctx context.Context, d *schema.ResourceData, m interf
 		d.Set("rotate", "")
 		d.Set("rotate_from", "")
 	}
+
+	if d.HasChange("key_ops") {
+		security_object := map[string]interface{}{
+			"kid": d.Get("kid").(string),
+		}
+		security_object["key_ops"] = d.Get("key_ops")
+
+		req, err := m.(*api_client).APICallBody("PATCH", fmt.Sprintf("crypto/v1/keys/%s", d.Id()), security_object)
+			if err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "[DSM SDK] Unable to call DSM provider API client",
+					Detail:   fmt.Sprintf("[E]: API: PATCH crypto/v1/keys: %v", err),
+				})
+				return diags
+			}
+
+		key_ops := make([]string, len(req["key_ops"].([]interface{})))
+		if err := d.Get("key_ops").([]interface{}); len(err) > 0 {
+			if len(d.Get("key_ops").([]interface{})) == len(req["key_ops"].([]interface{})) {
+				for idx, key_op := range d.Get("key_ops").([]interface{}) {
+					key_ops[idx] = fmt.Sprint(key_op)
+				}
+			} else {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "[DSM SDK] Unable to call DSM provider API client",
+					Detail:   fmt.Sprintf("[E]: API: PATCH crypto/v1/keys: Sync issue from State and DSM"),
+				})
+				return diags
+			}
+		} else {
+			for idx, key_op := range req["key_ops"].([]interface{}) {
+				key_ops[idx] = fmt.Sprint(key_op)
+			}
+		}
+		if err := d.Set("key_ops", key_ops); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceReadSobject(ctx, d, m)
 }
 

--- a/dsm/signer.go
+++ b/dsm/signer.go
@@ -1,0 +1,215 @@
+// **********
+// Terraform Provider - DSM: signer client
+// **********
+//       - Author:    fyoo at fortanix dot com
+//       - Version:   0.5.15
+//       - Date:      14/06/2022
+// **********
+
+package dsm
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+type dsmsigner struct {
+	crypto.Signer
+	crypto.Decrypter
+
+	kid        string
+	api_client *api_client
+
+	Cn    string
+	Ou    string
+	L     string
+	C     string
+	O     string
+	St    string
+	Email string
+	San   string
+}
+
+func (dsmsigner *dsmsigner) setProperty(propName string, propValue string) *dsmsigner {
+	reflect.ValueOf(dsmsigner).Elem().FieldByName(propName).Set(reflect.ValueOf(propValue))
+	return dsmsigner
+}
+
+func NewDSMSigner(kid string, san string, email string, cn string, ou string, l string, c string, o string, st string, api_client *api_client) (*dsmsigner, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var new_signer = &dsmsigner{
+		kid:        kid,
+		api_client: api_client,
+	}
+
+	if len(cn) > 0 {
+		new_signer.setProperty("Cn", cn)
+	}
+	if len(ou) > 0 {
+		new_signer.setProperty("Ou", ou)
+	}
+	if len(l) > 0 {
+		new_signer.setProperty("L", l)
+	}
+	if len(c) > 0 {
+		new_signer.setProperty("C", c)
+	}
+	if len(st) > 0 {
+		new_signer.setProperty("St", st)
+	}
+	if len(o) > 0 {
+		new_signer.setProperty("O", o)
+	}
+	if len(email) > 0 {
+		new_signer.setProperty("Email", email)
+	}
+	if len(san) > 0 {
+		new_signer.setProperty("San", san)
+	}
+
+	return new_signer, diags
+}
+
+// generate_csr: Generate CSR locally
+func (dsmsigner *dsmsigner) generate_csr() (string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var subj pkix.Name
+	subj.CommonName = dsmsigner.Cn
+
+	if dsmsigner.C != "" {
+		subj.Country = []string{dsmsigner.C}
+	}
+	if dsmsigner.St != "" {
+		subj.Province = []string{dsmsigner.St}
+	}
+	if dsmsigner.L != "" {
+		subj.Locality = []string{dsmsigner.L}
+	}
+	if dsmsigner.O != "" {
+		subj.Organization = []string{dsmsigner.O}
+	}
+	if dsmsigner.Ou != "" {
+		subj.OrganizationalUnit = []string{dsmsigner.Ou}
+	}
+
+	rawSubj := subj.ToRDNSequence()
+
+	// need to duplicate unfortunately
+	if dsmsigner.Email != "" {
+		var oidEmailAddress = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 1}
+
+		rawSubj = append(rawSubj, []pkix.AttributeTypeAndValue{
+			{Type: oidEmailAddress, Value: dsmsigner.Email},
+		})
+	}
+
+	asn1Subj, _ := asn1.Marshal(rawSubj)
+	template := x509.CertificateRequest{
+		RawSubject:         asn1Subj,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+
+	// need to duplicate unfortunately
+	if dsmsigner.Email != "" {
+		template.EmailAddresses = []string{dsmsigner.Email}
+	}
+
+	// FYOO: SAN support
+	if dsmsigner.San != "" {
+		extSubjectAltName := pkix.Extension{}
+		extSubjectAltName.Id = asn1.ObjectIdentifier{2, 5, 29, 17}
+		extSubjectAltName.Critical = false
+		extSubjectAltName.Value = []byte(dsmsigner.San)
+		template.ExtraExtensions = []pkix.Extension{extSubjectAltName}
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, dsmsigner)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "[DSM SDK] Unable to generate CSR",
+			Detail:   fmt.Sprintf("[E]: SDK: Terraform: %s", err),
+		})
+		return "", diags
+	}
+	//pem.Encode(os.Stdout, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+	generated_csr := pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrBytes,
+	}
+
+	generated_csr_pem := string(pem.EncodeToMemory(&generated_csr))
+
+	return generated_csr_pem, diags
+}
+
+func (dsmsigner dsmsigner) Public() crypto.PublicKey {
+	req, _, err := dsmsigner.api_client.APICall("GET", fmt.Sprintf("crypto/v1/keys/%s", dsmsigner.kid))
+	if err != nil {
+		panic("Unable to call DSM")
+	}
+
+	fxPubKeyDer, _ := base64.StdEncoding.DecodeString(req["pub_key"].(string))
+
+	fxPubKeyBlock := pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: fxPubKeyDer,
+	}
+
+	fxPubKeyPem := string(pem.EncodeToMemory(&fxPubKeyBlock))
+
+	pubKeyBlock, _ := pem.Decode([]byte(fxPubKeyPem))
+	if pubKeyBlock == nil {
+		panic("failed to parse PEM block containing the public key")
+	}
+
+	pubKey, err1 := x509.ParsePKIXPublicKey(pubKeyBlock.Bytes)
+	if err1 != nil {
+		panic("failed to parse DER encoded public key: " + err1.Error())
+	}
+
+	return pubKey
+}
+
+func (dsmsigner dsmsigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	hash := opts.HashFunc()
+	if len(digest) != hash.Size() {
+		return nil, fmt.Errorf("[DSM SDK]: signer: Digest length doesn't match crypto algorithm")
+	}
+
+	sign_op := map[string]interface{}{
+		"kid":      dsmsigner.kid,
+		"hash_alg": "SHA256",
+		"data":     base64.StdEncoding.EncodeToString(digest),
+	}
+
+	reqfpi, err := dsmsigner.api_client.FindPluginId("Terraform Plugin - CSR")
+	if err != nil {
+		return nil, fmt.Errorf("[DSM SDK]: signer: Unable to call DSM provider API client: GET: sys/v1/plugins: %v", err)
+	}
+	var endpoint = fmt.Sprintf("sys/v1/plugins/%s", string(reqfpi))
+	var operation = "POST"
+
+	req, err := dsmsigner.api_client.APICallBody(operation, endpoint, sign_op)
+	if err != nil {
+		return nil, fmt.Errorf("[DSM SDK]: signer: Unable to call DSM provider API client: POST: sys/v1/plugins: %v", err)
+	}
+
+	signature, err1 := base64.StdEncoding.DecodeString(req["signature"].(string))
+	if err1 != nil {
+		return nil, fmt.Errorf("[DSM SDK]: unable to convert from base64")
+	}
+	return signature, nil
+}

--- a/plugins/Terraform-Plugin-CSR.lua
+++ b/plugins/Terraform-Plugin-CSR.lua
@@ -1,0 +1,70 @@
+--
+--
+-- IMPORT: Name "Terraform Plugin - CSR"
+--
+--
+-- EXAMPLES:
+--
+-- ```
+-- {
+--   "subject_key": "my server key",
+--   "cert_lifetime": 86400,
+--   "subject_dn": { "CN": "localhost", "OU": "Testing" }
+-- }
+-- ```
+
+function check(input)
+   if type(input) ~= 'table' then
+      return nil, 'invalid input'
+   end
+   if not input.subject_dn then
+      return nil, 'must provide subject DN'
+   end
+   if not input.subject_key then
+      return nil, 'must provide subject key'
+   end
+end
+
+function format_pem(b64, type)
+   local wrap_at = 64
+   local len = string.len(b64)
+   local pem = ""
+
+   pem = pem .. "-----BEGIN " .. type .. "-----\n"
+
+   for i = 1, len, wrap_at do
+      local stop = i + wrap_at - 1
+      pem = pem .. string.sub(b64, i, stop) .. "\n"
+   end
+
+   pem = pem .. "-----END " .. type .. "-----\n"
+
+   return pem
+end
+
+function load_dn(dn)
+   local name = X509Name.new()
+
+   for k,v in pairs(dn)
+   do
+      name:set(Oid.from_str(k), v, 'utf8')
+   end
+
+   return name
+end
+
+function run(input)
+   local something_key = assert(Sobject { kid = input.subject_key })
+
+   local subject_dn = load_dn(input.subject_dn)
+   -- log the DN here?
+
+   local csr = Pkcs10Csr.new(something_key.name, subject_dn)
+
+   local conv = Blob.from_bytes(csr:to_der())
+   return {
+      value = format_pem(conv:base64(), "CERTIFICATE REQUEST"),
+      kid = something_key.kid,
+      id = tostring(Time.now_insecure()[1])
+   }
+end

--- a/plugins/Terraform-Plugin-CSR.lua
+++ b/plugins/Terraform-Plugin-CSR.lua
@@ -65,6 +65,6 @@ function run(input)
    --local csr = Pkcs10Csr.new(something_key.name, subject_dn)
 
    --local conv = Blob.from_bytes(csr:to_der())
-   local signature = assert(signing_key:sign { data = input.data, hash_alg = input.hash_alg })
+   local signature = assert(signing_key:sign { hash = input.data, hash_alg = input.hash_alg })
    return signature
 end


### PR DESCRIPTION
The following has been updated:
- Ability to create CSR as a resource
- Proxy support from ENV variable
- Fixed issues with SObject showing modification on the key_ops even though there are no changes

Need to be supported:
- Import CSR's at a later stage so can be used as a data source
- Other x509 extensions as required