### PR TITLE
Add default value of empty json for approval policy item in group creation

### DIFF
--- a/dsm/resource_group.go
+++ b/dsm/resource_group.go
@@ -52,6 +52,7 @@ func resourceGroup() *schema.Resource {
 			"approval_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "{}",
 			},
 		},
 		Importer: &schema.ResourceImporter{


### PR DESCRIPTION
A bug has been reported about Terraform erroring out when creating a group without a quorum policy. Default value of empty JSON has been added to group definition.