### PR TITLE
DEVOPS-4882

### DIFF
--- a/dsm/resource_sobject.go
+++ b/dsm/resource_sobject.go
@@ -497,11 +497,7 @@ func resourceReadSobject(ctx context.Context, d *schema.ResourceData, m interfac
 					return diag.FromErr(err)
 				}
 			} else {
-				fpe_bytes, ok := json.Marshal(req["fpe"].(map[string]interface{}))
-				if ok != nil {
-					return diag.FromErr(ok)
-				}
-				if err := d.Set("fpe", string(fpe_bytes)); err != nil {
+				if err := d.Set("fpe", (d.Get("fpe").(string)) ); err != nil {
 					return diag.FromErr(err)
 				}
 			}


### PR DESCRIPTION
The error is coming when we try to update an existing fpe object. The terraform statefile has fpeOptions that are different from the fpeOptions in config file because the statefile is being built from the response from key creation, which can send fpeOptions that can have more attributes than what are present in config file (like applied_to attribute in fpeOptions).

To rectify this, I am building the fpeOptions in statefile from the config file itself. This will not create any differences in statefile fpeOptions and config file fpeOptions 