### PR TITLE
In this PR, PROD-9281 has been fixed.

### DIFF
--- a/docs-archived/guides/dsm_azure_sobject.md
+++ b/docs-archived/guides/dsm_azure_sobject.md
@@ -197,7 +197,7 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 ## Purging a dsm_azure_sobject.
 
 # Enable purge_deleted_key as true.
-# This can be enabled only after soft_deletion can this be enabled during an update
+# Only after soft_deletion can this be enabled during an update
 resource "dsm_azure_sobject" "rsa_key_azure" {
   name     = "rsa_key_azure"
   group_id = dsm_group.azure_group.id

--- a/docs-archived/guides/dsm_azure_sobject.md
+++ b/docs-archived/guides/dsm_azure_sobject.md
@@ -61,7 +61,7 @@ resource "dsm_azure_sobject" "rsa_key_azure_rotate1" {
     kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as the key copied to the Azure group
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "DSM"
@@ -79,7 +79,7 @@ resource "dsm_azure_sobject" "rsa_key_azure_rotate2" {
     kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above 
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as the key copied to the Azure group 
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "DSM"
@@ -149,7 +149,7 @@ resource "dsm_azure_sobject" "rsa_key_azure_rotate1" {
     kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as the key copied to the Azure group
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "AZURE"
@@ -166,7 +166,7 @@ resource "dsm_azure_sobject" "rsa_key_azure_rotate2" {
     kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as the key copied to the Azure group
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "AZURE"
@@ -197,7 +197,7 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 ## Purging a dsm_azure_sobject.
 
 # Enable purge_deleted_key as true.
-# This can be enabled only during update and can be done only after soft_deletion.
+# This can be enabled only after soft_deletion can this be enabled during an update
 resource "dsm_azure_sobject" "rsa_key_azure" {
   name     = "rsa_key_azure"
   group_id = dsm_group.azure_group.id

--- a/docs-archived/guides/dsm_azure_sobject.md
+++ b/docs-archived/guides/dsm_azure_sobject.md
@@ -53,60 +53,39 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 
 ## 1st Rotation of azure security object with DSM option
 
-# Rotate RSA security object
-resource "dsm_sobject" "rsa_key_dsm_rotate1" {
-  name        = dsm_sobject.rsa_key_dsm.name
-  group_id    = dsm_group.normal_group.id
-  key_size    = 2048
-  key_ops     = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "SIGN", "VERIFY", "EXPORT"]
-  obj_type    = "RSA"
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.rsa_key_dsm.name
-}
-
-# Copy above RSA key to azure key vault
+# Just copy the above dsm_azure_sobject.rsa_key_azure, add rotate and rotate_from attributes and change the resource name
 resource "dsm_azure_sobject" "rsa_key_azure_rotate1" {
-  name     = dsm_azure_sobject.rsa_key_azure.name
+  name     = dsm_azure_sobject.rsa_key_azure.name # Name should be the same as the key to be rotated.
   group_id = dsm_group.azure_group.id
   key = {
-    kid = dsm_sobject.rsa_key_dsm_rotate1.id
+    kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure"
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "DSM"
-  rotate_from = dsm_azure_sobject.rsa_key_azure.name
+  rotate_from = dsm_azure_sobject.rsa_key_azure.name # Name of the key from where it is being rotated.
 }
 
 
 ## 2nd Rotation of azure security object with DSM option
 
-# Rotate RSA security object
-resource "dsm_sobject" "rsa_key_dsm_rotate2" {
-  name        = es.rsa_key_dsm.name
-  group_id    = dsm_group.normal_group.id
-  key_size    = 2048
-  key_ops     = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "SIGN", "VERIFY", "EXPORT"]
-  obj_type    = "RSA"
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.rsa_key_dsm.name
-}
-
-# Copy above RSA key to azure key vault
+# Just copy the above dsm_azure_sobject.rsa_key_azure_rotate1, add rotate and rotate_from attributes and change the resource name
 resource "dsm_azure_sobject" "rsa_key_azure_rotate2" {
-  name     = dsm_azure_sobject.rsa_key_azure.name
+  name     = dsm_azure_sobject.rsa_key_azure_rotate1.name # Name should be the same as the key name to be rotated.
   group_id = dsm_group.azure_group.id
   key = {
-    kid = dsm_sobject.rsa_key_dsm_rotate2.id
+    kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure"
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above 
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "DSM"
-  rotate_from = dsm_azure_sobject.rsa_key_azure.name
+  rotate_from = dsm_azure_sobject.rsa_key_azure_rotate1.name # Name of the key from where it is being rotated.
 }
+
 ```
 
 ## Rotate with AZURE Option
@@ -162,58 +141,36 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 
 ## 1st Rotation of azure security object with AZURE option
 
-# Rotate RSA security object
-resource "dsm_sobject" "rsa_key_dsm_rotate1" {
-  name        = dsm_sobject.rsa_key_dsm.name
-  group_id    = dsm_group.normal_group.id
-  key_size    = 2048
-  key_ops     = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "SIGN", "VERIFY", "EXPORT"]
-  obj_type    = "RSA"
-  rotate      = "AZURE"
-  rotate_from = dsm_sobject.rsa_key_dsm.name
-}
-
-# Copy above RSA key to azure key vault
+# Just copy the above dsm_azure_sobject.rsa_key_azure, add rotate and rotate_from attributes and change the resource name
 resource "dsm_azure_sobject" "rsa_key_azure_rotate1" {
-  name     = dsm_azure_sobject.rsa_key_azure.name
+  name     = dsm_azure_sobject.rsa_key_azure.name # Name should be the same as the key name to be rotated.
   group_id = dsm_group.azure_group.id
   key = {
-    kid = dsm_sobject.rsa_key_dsm_rotate1.id
+    kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure"
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "AZURE"
-  rotate_from = dsm_azure_sobject.rsa_key_azure.name
+  rotate_from = dsm_azure_sobject.rsa_key_azure.name # Name of the key from where it is being rotated.
 }
 
 ## 2nd Rotation of azure security object with AZURE option
 
-# Rotate RSA security object
-resource "dsm_sobject" "rsa_key_dsm_rotate2" {
-  name        = dsm_sobject.rsa_key_dsm.name
-  group_id    = dsm_group.normal_group.id
-  key_size    = 2048
-  key_ops     = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "SIGN", "VERIFY", "EXPORT"]
-  obj_type    = "RSA"
-  rotate      = "AZURE"
-  rotate_from = dsm_sobject.rsa_key_dsm.name
-}
-
-# Copy above RSA key to azure key vault
+# Just copy the above dsm_azure_sobject.rsa_key_azure_rotate1, add rotate and rotate_from attributes and change the resource name
 resource "dsm_azure_sobject" "rsa_key_azure_rotate2" {
-  name     = dsm_azure_sobject.rsa_key_azure.name
+  name     = dsm_azure_sobject.rsa_key_azure_rotate1.name # Name should be the same as the key name to be rotated.
   group_id = dsm_group.azure_group.id
   key = {
-    kid = dsm_sobject.rsa_key_dsm_rotate2.id
+    kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure"
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "AZURE"
-  rotate_from = dsm_azure_sobject.rsa_key_azure.name
+  rotate_from = dsm_azure_sobject.rsa_key_azure_rotate1.name # Name of the key from where it is being rotated.
 }
 ```
 
@@ -237,11 +194,10 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
   soft_deletion = true
 }
 
-
 ## Purging a dsm_azure_sobject.
 
 # Enable purge_deleted_key as true.
-# This can be enabled only during update.
+# This can be enabled only during update and can be done only after soft_deletion.
 resource "dsm_azure_sobject" "rsa_key_azure" {
   name     = "rsa_key_azure"
   group_id = dsm_group.azure_group.id
@@ -258,6 +214,7 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 ## Soft deletion and Purging a key in a single request.
 
 # First it does the soft deletion and then purging the key.
+# These can be enabled only during update.
 resource "dsm_azure_sobject" "rsa_key_azure" {
   name     = "rsa_key_azure"
   group_id = dsm_group.azure_group.id

--- a/docs/guides/dsm_azure_sobject.md
+++ b/docs/guides/dsm_azure_sobject.md
@@ -197,7 +197,7 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 ## Purging a dsm_azure_sobject.
 
 # Enable purge_deleted_key as true.
-# This can be enabled only after soft_deletion can this be enabled during an update
+# Only after soft_deletion can this be enabled during an update
 resource "dsm_azure_sobject" "rsa_key_azure" {
   name     = "rsa_key_azure"
   group_id = dsm_group.azure_group.id

--- a/docs/guides/dsm_azure_sobject.md
+++ b/docs/guides/dsm_azure_sobject.md
@@ -61,7 +61,7 @@ resource "dsm_azure_sobject" "rsa_key_azure_rotate1" {
     kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as the key copied to the Azure group
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "DSM"
@@ -79,7 +79,7 @@ resource "dsm_azure_sobject" "rsa_key_azure_rotate2" {
     kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above 
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as the key copied to the Azure group 
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "DSM"
@@ -149,7 +149,7 @@ resource "dsm_azure_sobject" "rsa_key_azure_rotate1" {
     kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as the key copied to the Azure group
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "AZURE"
@@ -166,7 +166,7 @@ resource "dsm_azure_sobject" "rsa_key_azure_rotate2" {
     kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as the key copied to the Azure group
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "AZURE"
@@ -197,7 +197,7 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 ## Purging a dsm_azure_sobject.
 
 # Enable purge_deleted_key as true.
-# This can be enabled only during update and can be done only after soft_deletion.
+# This can be enabled only after soft_deletion can this be enabled during an update
 resource "dsm_azure_sobject" "rsa_key_azure" {
   name     = "rsa_key_azure"
   group_id = dsm_group.azure_group.id

--- a/docs/guides/dsm_azure_sobject.md
+++ b/docs/guides/dsm_azure_sobject.md
@@ -53,60 +53,39 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 
 ## 1st Rotation of azure security object with DSM option
 
-# Rotate RSA security object
-resource "dsm_sobject" "rsa_key_dsm_rotate1" {
-  name        = dsm_sobject.rsa_key_dsm.name
-  group_id    = dsm_group.normal_group.id
-  key_size    = 2048
-  key_ops     = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "SIGN", "VERIFY", "EXPORT"]
-  obj_type    = "RSA"
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.rsa_key_dsm.name
-}
-
-# Copy above RSA key to azure key vault
+# Just copy the above dsm_azure_sobject.rsa_key_azure, add rotate and rotate_from attributes and change the resource name
 resource "dsm_azure_sobject" "rsa_key_azure_rotate1" {
-  name     = dsm_azure_sobject.rsa_key_azure.name
+  name     = dsm_azure_sobject.rsa_key_azure.name # Name should be the same as the key to be rotated.
   group_id = dsm_group.azure_group.id
   key = {
-    kid = dsm_sobject.rsa_key_dsm_rotate1.id
+    kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure"
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "DSM"
-  rotate_from = dsm_azure_sobject.rsa_key_azure.name
+  rotate_from = dsm_azure_sobject.rsa_key_azure.name # Name of the key from where it is being rotated.
 }
 
 
 ## 2nd Rotation of azure security object with DSM option
 
-# Rotate RSA security object
-resource "dsm_sobject" "rsa_key_dsm_rotate2" {
-  name        = es.rsa_key_dsm.name
-  group_id    = dsm_group.normal_group.id
-  key_size    = 2048
-  key_ops     = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "SIGN", "VERIFY", "EXPORT"]
-  obj_type    = "RSA"
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.rsa_key_dsm.name
-}
-
-# Copy above RSA key to azure key vault
+# Just copy the above dsm_azure_sobject.rsa_key_azure_rotate1, add rotate and rotate_from attributes and change the resource name
 resource "dsm_azure_sobject" "rsa_key_azure_rotate2" {
-  name     = dsm_azure_sobject.rsa_key_azure.name
+  name     = dsm_azure_sobject.rsa_key_azure_rotate1.name # Name should be the same as the key name to be rotated.
   group_id = dsm_group.azure_group.id
   key = {
-    kid = dsm_sobject.rsa_key_dsm_rotate2.id
+    kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure"
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above 
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "DSM"
-  rotate_from = dsm_azure_sobject.rsa_key_azure.name
+  rotate_from = dsm_azure_sobject.rsa_key_azure_rotate1.name # Name of the key from where it is being rotated.
 }
+
 ```
 
 ## Rotate with AZURE Option
@@ -162,58 +141,36 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 
 ## 1st Rotation of azure security object with AZURE option
 
-# Rotate RSA security object
-resource "dsm_sobject" "rsa_key_dsm_rotate1" {
-  name        = dsm_sobject.rsa_key_dsm.name
-  group_id    = dsm_group.normal_group.id
-  key_size    = 2048
-  key_ops     = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "SIGN", "VERIFY", "EXPORT"]
-  obj_type    = "RSA"
-  rotate      = "AZURE"
-  rotate_from = dsm_sobject.rsa_key_dsm.name
-}
-
-# Copy above RSA key to azure key vault
+# Just copy the above dsm_azure_sobject.rsa_key_azure, add rotate and rotate_from attributes and change the resource name
 resource "dsm_azure_sobject" "rsa_key_azure_rotate1" {
-  name     = dsm_azure_sobject.rsa_key_azure.name
+  name     = dsm_azure_sobject.rsa_key_azure.name # Name should be the same as the key name to be rotated.
   group_id = dsm_group.azure_group.id
   key = {
-    kid = dsm_sobject.rsa_key_dsm_rotate1.id
+    kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure"
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "AZURE"
-  rotate_from = dsm_azure_sobject.rsa_key_azure.name
+  rotate_from = dsm_azure_sobject.rsa_key_azure.name # Name of the key from where it is being rotated.
 }
 
 ## 2nd Rotation of azure security object with AZURE option
 
-# Rotate RSA security object
-resource "dsm_sobject" "rsa_key_dsm_rotate2" {
-  name        = dsm_sobject.rsa_key_dsm.name
-  group_id    = dsm_group.normal_group.id
-  key_size    = 2048
-  key_ops     = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "SIGN", "VERIFY", "EXPORT"]
-  obj_type    = "RSA"
-  rotate      = "AZURE"
-  rotate_from = dsm_sobject.rsa_key_dsm.name
-}
-
-# Copy above RSA key to azure key vault
+# Just copy the above dsm_azure_sobject.rsa_key_azure_rotate1, add rotate and rotate_from attributes and change the resource name
 resource "dsm_azure_sobject" "rsa_key_azure_rotate2" {
-  name     = dsm_azure_sobject.rsa_key_azure.name
+  name     = dsm_azure_sobject.rsa_key_azure_rotate1.name # Name should be the same as the key name to be rotated.
   group_id = dsm_group.azure_group.id
   key = {
-    kid = dsm_sobject.rsa_key_dsm_rotate2.id
+    kid = dsm_sobject.rsa_key_dsm.id
   }
   custom_metadata = {
-    azure-key-name  = "rsa-key-azure"
+    azure-key-name  = "rsa-key-azure" # Should be the same azure-key-name as above
   }
   key_ops     = ["SIGN", "VERIFY", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "EXPORT", "APPMANAGEABLE", "HIGHVOLUME"]
   rotate      = "AZURE"
-  rotate_from = dsm_azure_sobject.rsa_key_azure.name
+  rotate_from = dsm_azure_sobject.rsa_key_azure_rotate1.name # Name of the key from where it is being rotated.
 }
 ```
 
@@ -237,11 +194,10 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
   soft_deletion = true
 }
 
-
 ## Purging a dsm_azure_sobject.
 
 # Enable purge_deleted_key as true.
-# This can be enabled only during update.
+# This can be enabled only during update and can be done only after soft_deletion.
 resource "dsm_azure_sobject" "rsa_key_azure" {
   name     = "rsa_key_azure"
   group_id = dsm_group.azure_group.id
@@ -258,6 +214,7 @@ resource "dsm_azure_sobject" "rsa_key_azure" {
 ## Soft deletion and Purging a key in a single request.
 
 # First it does the soft deletion and then purging the key.
+# These can be enabled only during update.
 resource "dsm_azure_sobject" "rsa_key_azure" {
   name     = "rsa_key_azure"
   group_id = dsm_group.azure_group.id

--- a/docs/resources/azure_sobject.md
+++ b/docs/resources/azure_sobject.md
@@ -8,7 +8,7 @@ description: |-
   Note: Once soft deletion is enabled, Azure sobject can't be modified.
   Deletion of a dsm_azure_sobject: Unlike dsm_sobject, deletion of a dsm_azure_sobject is not normal.
   Steps to delete a dsm_azure_sobject:
-  Enable soft_deletion as shown in the examples of guides/dsm_azure_sobject.Enable purge_deleted_key after soft_deletion as shown in the examples of guides/dsm_azure_sobject.A dsm_azure_sobject can be deleted completely only when its state is destroyed.A dsm_azure_sobject comes to destroyed state when the key is deleted from Azure key vault.To know whether it is in a destroyed state or not, sync keys operation should be performed.Use dsm_azure_group data_source to sync the keys. Please refer Data Sources/dsm_azure_group.
+  Enable soft_deletion as shown in the examples of Guides/dsm_azure_sobject.Enable purge_deleted_key after soft_deletion as shown in the examples of Guides/dsm_azure_sobject.A dsm_azure_sobject can be deleted completely only when its state is destroyed.A dsm_azure_sobject comes to destroyed state when the key is deleted from Azure key vault.To know whether it is in a destroyed state or not, sync keys operation should be performed.Use dsm_azure_group data_source to sync the keys. Please refer Data Sources/dsm_azure_group.
 ---
 
 # dsm_azure_sobject (Resource)
@@ -23,12 +23,12 @@ Azure sobject can also rotate, enable soft deletion and purge the key. For examp
 
 **Steps to delete a dsm_azure_sobject**:
 
-   * Enable soft_deletion as shown in the examples of guides/dsm_azure_sobject.
-   * Enable purge_deleted_key after soft_deletion as shown in the examples of guides/dsm_azure_sobject.
+   * Enable soft_deletion as shown in the examples of `Guides/dsm_azure_sobject`.
+   * Enable purge_deleted_key after soft_deletion as shown in the examples of `Guides/dsm_azure_sobject`.
    * A dsm_azure_sobject can be deleted completely only when its state is `destroyed`.
    * A dsm_azure_sobject comes to destroyed state when the key is deleted from Azure key vault.
    * To know whether it is in a destroyed state or not, sync keys operation should be performed.
-   * Use dsm_azure_group data_source to sync the keys. Please refer Data Sources/dsm_azure_group.
+   * Use `dsm_azure_group` data_source to sync the keys. Please refer Data `Sources/dsm_azure_group`.
 
 ## Example Usage
 

--- a/docs/resources/azure_sobject.md
+++ b/docs/resources/azure_sobject.md
@@ -8,7 +8,7 @@ description: |-
   Note: Once soft deletion is enabled, Azure sobject can't be modified.
   Deletion of a dsm_azure_sobject: Unlike dsm_sobject, deletion of a dsm_azure_sobject is not normal.
   Steps to delete a dsm_azure_sobject:
-  Enable soft_deletion as shown in the examples of guides/dsm_azure_sobject.Enable purge_deleted_key after soft_deletion as shown in the examples of guides/dsm_azure_sobject.A dsm_azure_sobject can be deleted completely only when its state is destroyed.A dsm_azure_sobject comes to destroyed state when the key is deleted from Azure key vault.To know whether it is in a destroyed state or not, sync keys operation should be performed.Currently, sync keys is not supported by terraform. This can be done in UI by going to the group and HSM/KMS. Then click on SYNC KEYS.
+  Enable soft_deletion as shown in the examples of guides/dsm_azure_sobject.Enable purge_deleted_key after soft_deletion as shown in the examples of guides/dsm_azure_sobject.A dsm_azure_sobject can be deleted completely only when its state is destroyed.A dsm_azure_sobject comes to destroyed state when the key is deleted from Azure key vault.To know whether it is in a destroyed state or not, sync keys operation should be performed.Use dsm_azure_group data_source to sync the keys. Please refer Data Sources/dsm_azure_group.
 ---
 
 # dsm_azure_sobject (Resource)
@@ -28,7 +28,7 @@ Azure sobject can also rotate, enable soft deletion and purge the key. For examp
    * A dsm_azure_sobject can be deleted completely only when its state is `destroyed`.
    * A dsm_azure_sobject comes to destroyed state when the key is deleted from Azure key vault.
    * To know whether it is in a destroyed state or not, sync keys operation should be performed.
-   * Currently, sync keys is not supported by terraform. This can be done in UI by going to the group and HSM/KMS. Then click on `SYNC KEYS`.
+   * Use dsm_azure_group data_source to sync the keys. Please refer Data Sources/dsm_azure_group.
 
 ## Example Usage
 

--- a/dsm/common.go
+++ b/dsm/common.go
@@ -322,6 +322,7 @@ func showWarning(msg string) diag.Diagnostics {
 	var diags diag.Diagnostics
 	diags = append(diags, diag.Diagnostic{
 		Severity: diag.Warning,
+		Summary:  "[DSM SDK] Unable to call DSM provider API client",
 		Detail:   fmt.Sprintf("[W]: %s", msg),
 	})
 	return diags

--- a/dsm/resource_azure_sobject.go
+++ b/dsm/resource_azure_sobject.go
@@ -415,7 +415,7 @@ func resourceUpdateAzureSobject(ctx context.Context, d *schema.ResourceData, m i
 			// This is when purge_deleted_key is enabled along with soft_deletion.
 			// When a user has a bunch of azure keys and enables both soft_deletion and purge_deleted_key at a time,
 			// then there is a high possibility of getting the error 'key is being deleted' from AKV.
-			// As it takes sometime to delete the key at AKV, sleep is added for 3 seconds.
+			// As it takes sometime to delete the key at AKV, sleep has been added.
 			time.Sleep(3 * time.Second)
 		}
 	}

--- a/dsm/resource_azure_sobject.go
+++ b/dsm/resource_azure_sobject.go
@@ -44,7 +44,7 @@ func resourceAzureSobject() *schema.Resource {
 		"   * A dsm_azure_sobject can be deleted completely only when its state is `destroyed`.\n" +
 		"   * A dsm_azure_sobject comes to destroyed state when the key is deleted from Azure key vault.\n" +
 		"   * To know whether it is in a destroyed state or not, sync keys operation should be performed.\n" +
-		"   * Currently, sync keys is not supported by terraform. This can be done in UI by going to the group and HSM/KMS. Then click on `SYNC KEYS`.",
+		"   * Use dsm_azure_group data_source to sync the keys. Please refer Data Sources/dsm_azure_group.",
 		Schema: map[string]*schema.Schema{
 			"name": {
 			    Description: "The security object name.",

--- a/dsm/resource_azure_sobject.go
+++ b/dsm/resource_azure_sobject.go
@@ -39,12 +39,12 @@ func resourceAzureSobject() *schema.Resource {
 		"**Note**: Once soft deletion is enabled, Azure sobject can't be modified.\n\n" +
 		"**Deletion of a dsm_azure_sobject:** Unlike dsm_sobject, deletion of a dsm_azure_sobject is not normal.\n\n" +
 		"**Steps to delete a dsm_azure_sobject**:\n\n" +
-		"   * Enable soft_deletion as shown in the examples of guides/dsm_azure_sobject.\n" +
-		"   * Enable purge_deleted_key after soft_deletion as shown in the examples of guides/dsm_azure_sobject.\n" +
+		"   * Enable soft_deletion as shown in the examples of `Guides/dsm_azure_sobject`.\n" +
+		"   * Enable purge_deleted_key after soft_deletion as shown in the examples of `Guides/dsm_azure_sobject`.\n" +
 		"   * A dsm_azure_sobject can be deleted completely only when its state is `destroyed`.\n" +
 		"   * A dsm_azure_sobject comes to destroyed state when the key is deleted from Azure key vault.\n" +
 		"   * To know whether it is in a destroyed state or not, sync keys operation should be performed.\n" +
-		"   * Use dsm_azure_group data_source to sync the keys. Please refer Data Sources/dsm_azure_group.",
+		"   * Use `dsm_azure_group` data_source to sync the keys. Please refer Data `Sources/dsm_azure_group`.",
 		Schema: map[string]*schema.Schema{
 			"name": {
 			    Description: "The security object name.",
@@ -415,7 +415,7 @@ func resourceUpdateAzureSobject(ctx context.Context, d *schema.ResourceData, m i
 			// This is when purge_deleted_key is enabled along with soft_deletion.
 			// When a user has a bunch of azure keys and enables both soft_deletion and purge_deleted_key at a time,
 			// then there is a high possibility of getting the error 'key is being deleted' from AKV.
-			// As it takes sometime to delete the key at AKV, sleep is added for 5 seconds.
+			// As it takes sometime to delete the key at AKV, sleep is added for 3 seconds.
 			time.Sleep(3 * time.Second)
 		}
 	}


### PR DESCRIPTION
Issue1: When purge_deleted_key is enabled, it actually purging the key but shows a warning.

Issue2: When multiple keys are created, and enabled both soft_deletion and purge_deleted_key in the same request,
	Intermittently it gives an error 'key is still being deleted' from azure key vault. This comes when multiple keys are tried to 
       purge.To fix this issue, wait time has been added of 3 seconds immediately after soft_deletion.

Above two issues were fixed and few doc changes.

 On branch PROD-9281
 Changes to be committed:
	modified:   docs-archived/guides/dsm_azure_sobject.md
	modified:   docs/guides/dsm_azure_sobject.md
	modified:   dsm/common.go
	modified:   dsm/resource_azure_sobject.go