### PR TITLE
Prod 9286

### DIFF
--- a/docs-archived/guides/dsm_aws_sobject.md
+++ b/docs-archived/guides/dsm_aws_sobject.md
@@ -209,9 +209,6 @@ resource "dsm_aws_sobject" "dsm_aws_sobject" {
 ```terraform
 # Add interval_months or interval_days. It should be an integer.
 # Add effective_at as a date format.
-# Disable deactivate_rotated_key as it is not supported.
-# deactivate_rotated_key is an optional attribute. Please specify this to to avoid the changes detected during terraform plan.
-
 resource "dsm_aws_sobject" "dsm_aws_sobject" {
   name     = "dsm_aws_sobject"
   group_id = dsm_group.dsm_aws_group.id
@@ -225,7 +222,6 @@ resource "dsm_aws_sobject" "dsm_aws_sobject" {
   rotation_policy = {
     interval_months        = 7
     effective_at           = "20260730T230000Z"
-    deactivate_rotated_key = false
   }
 }
 ```

--- a/docs-archived/guides/dsm_aws_sobject.md
+++ b/docs-archived/guides/dsm_aws_sobject.md
@@ -38,7 +38,7 @@ resource "dsm_sobject" "aes_sobject" {
   key_ops  = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
 }
 
-# AWS sobject creation(Copies the key from DSM)
+# Create the AWS key by copying the dsm_object as a virtual key in the AWS group
 resource "dsm_aws_sobject" "aws_sobject" {
   name        = "aws_sobject"
   group_id    = dsm_group.aws_group.id
@@ -52,108 +52,84 @@ resource "dsm_aws_sobject" "aws_sobject" {
   }
 }
 
-# 1st Rotation of dsm_sobject
-resource "dsm_sobject" "aes_sobject_rotate1" {
-  name        = "aes_sobject"
-  obj_type    = "AES"
-  group_id    = dsm_group.normal_group.id
-  key_size    = 256
-  key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.aes_sobject.name # Name of the old dsm_sobject
-}
-
 # 1st Rotation of dsm_aws_sobject
 resource "dsm_aws_sobject" "aws_sobject_rotate1" {
-  name        = "aws_sobject"
+  name        = dsm_aws_sobject.aws_sobject.name # Name should be the same as the key name to be rotated.
   group_id    = dsm_group.aws_group.id
   description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
   key = {
-    kid = dsm_sobject.aes_sobject_rotate1.id # 1st Rotated dsm_sbject
+    kid = dsm_sobject.aes_sobject.id
   }
   rotate      = "DSM"
-  rotate_from = dsm_aws_sobject.aws_sobject.name # Name of the old dsm_aws_sobject
-}
-
-
-# 2nd Rotation of dsm_sobject
-resource "dsm_sobject" "aes_sobject_rotate2" {
-  name        = "aes_sobject"
-  obj_type    = "AES"
-  group_id    = dsm_group.normal_group.id
-  key_size    = 256
-  key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.aes_sobject1.name # Name of the old dsm_sobject
+  rotate_from = dsm_aws_sobject.aws_sobject.name # Name of the key from where it is being rotated.
 }
 
 # 2nd Rotation of dsm_aws_sobject
 resource "dsm_aws_sobject" "aws_sobject_rotate2" {
-  name        = "aws_sobject"
+  name        = dsm_aws_sobject.aws_sobject_rotate1.name # Name should be the same as the key name to be rotated.
   group_id    = dsm_group.aws_group.id
   description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
   key = {
-    kid = dsm_sobject.aes_sobject_rotate2.id # 2nd Rotated dsm_sbject
+    kid = dsm_sobject.aes_sobject.id
   }
   rotate      = "DSM"
-  rotate_from = dsm_aws_sobject.aws_sobject_rotate1.name # Name of the old dsm_aws_sobject
+  rotate_from = dsm_aws_sobject.aws_sobject_rotate1.name # Name of the key from where it is being rotated.
 }
 ```
 
 ## Rotate with AWS Option
 
 ```terraform
-# 1st Rotation of dsm_sobject
-resource "dsm_sobject" "aes_sobject_rotate1" {
-  name        = "aes_sobject"
-  obj_type    = "AES"
-  group_id    = dsm_group.normal_group.id
-  key_size    = 256
+# Create a dsm_sobject of type AES key inside DSM
+resource "dsm_sobject" "aes_sobject" {
+  name     = "aes_sobject"
+  obj_type = "AES"
+  group_id = dsm_group.normal_group.id
+  key_size = 256
+  key_ops  = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
+}
+
+# Create the AWS key by copying the dsm_object as a virtual key in the AWS group
+resource "dsm_aws_sobject" "aws_sobject" {
+  name        = "aws_sobject"
+  group_id    = dsm_group.aws_group.id
+  description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.aes_sobject.name # Name of the old dsm_sobject
+  key = {
+    kid = dsm_sobject.aes_sobject.id
+  }
+  custom_metadata = {
+    aws-aliases = "dsm_aws_sobject"
+  }
 }
 
 # 1st Rotation of dsm_aws_sobject
 resource "dsm_aws_sobject" "aws_sobject_rotate1" {
-  name        = "aws_sobject"
+  name        = dsm_aws_sobject.aws_sobject.name # Name should be the same as the key name to be rotated.
   group_id    = dsm_group.aws_group.id
   description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
   key = {
-    kid = dsm_sobject.aes_sobject_rotate1.id # 1st Rotated dsm_sbject
+    kid = dsm_sobject.aes_sobject.id # 1st Rotated dsm_sbject
   }
   rotate      = "AWS"
-  rotate_from = dsm_aws_sobject.aws_sobject.name # Name of the old dsm_aws_sobject
-}
-
-
-# 2nd Rotation of dsm_sobject
-resource "dsm_sobject" "aes_sobject_rotate2" {
-  name        = "aes_sobject"
-  obj_type    = "AES"
-  group_id    = dsm_group.normal_group.id
-  key_size    = 256
-  key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.aes_sobject1.name # Name of the old dsm_sobject
+  rotate_from = dsm_aws_sobject.aws_sobject.name # Name of the key from where it is being rotated.
 }
 
 # 2nd Rotation of dsm_aws_sobject
 resource "dsm_aws_sobject" "aws_sobject_rotate2" {
-  name        = "aws_sobject"
+  name        = dsm_aws_sobject.aws_sobject_rotate1.name # Name should be the same as the key name to be rotated.
   group_id    = dsm_group.aws_group.id
   description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
   key = {
-    kid = dsm_sobject.aes_sobject_rotate2.id # 2nd Rotated dsm_sbject
+    kid = dsm_sobject.aes_sobject.id
   }
   rotate      = "AWS"
-  rotate_from = dsm_aws_sobject.aws_sobject_rotate1.name # Name of the old dsm_aws_sobject
+  rotate_from = dsm_aws_sobject.aws_sobject_rotate1.name # Name of the key from where it is being rotated.
 }
-
 ```
 
 
@@ -210,7 +186,7 @@ resource "dsm_aws_sobject" "dsm_aws_sobject" {
 ## Both schedule_deletion and delete_key_material can be enabled in a single terraform request
 
 ```terraform
-# Enable delete_key_material as true.
+# Enable delete_key_material as true and specify schedule deletion as an Integer. Value should be minimum 7.
 # This can be enabled only during update.
 resource "dsm_aws_sobject" "dsm_aws_sobject" {
   name     = "dsm_aws_sobject"
@@ -223,7 +199,35 @@ resource "dsm_aws_sobject" "dsm_aws_sobject" {
   }
   key_ops = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "EXPORT", "APPMANAGEABLE"]
   # schedule_deletion and delete key material
-  schedule_deletion   = 7
   delete_key_material = true
+  schedule_deletion   = 7
 }
+```
+
+## Example of adding a rotation_policy
+
+```terraform
+# Add interval_months or interval_days. It should be an integer.
+# Add effective_at as a date format.
+# Disable deactivate_rotated_key as it is not supported.
+# deactivate_rotated_key is an optional attribute. Please specify this to to avoid the changes detected during terraform plan.
+
+resource "dsm_aws_sobject" "dsm_aws_sobject" {
+  name     = "dsm_aws_sobject"
+  group_id = dsm_group.dsm_aws_group.id
+  key = {
+    kid = dsm_sobject.dsm_sobject.id
+  }
+  custom_metadata = {
+    aws-aliases = "dsm_aws_sobject"
+  }
+  key_ops = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "EXPORT", "APPMANAGEABLE"]
+  rotation_policy = {
+    interval_months        = 7
+    effective_at           = "20260730T230000Z"
+    deactivate_rotated_key = false
+  }
+}
+```
+
 ```

--- a/docs/guides/dsm_aws_sobject.md
+++ b/docs/guides/dsm_aws_sobject.md
@@ -209,9 +209,6 @@ resource "dsm_aws_sobject" "dsm_aws_sobject" {
 ```terraform
 # Add interval_months or interval_days. It should be an integer.
 # Add effective_at as a date format.
-# Disable deactivate_rotated_key as it is not supported.
-# deactivate_rotated_key is an optional attribute. Please specify this to to avoid the changes detected during terraform plan.
-
 resource "dsm_aws_sobject" "dsm_aws_sobject" {
   name     = "dsm_aws_sobject"
   group_id = dsm_group.dsm_aws_group.id
@@ -225,7 +222,6 @@ resource "dsm_aws_sobject" "dsm_aws_sobject" {
   rotation_policy = {
     interval_months        = 7
     effective_at           = "20260730T230000Z"
-    deactivate_rotated_key = false
   }
 }
 ```

--- a/docs/guides/dsm_aws_sobject.md
+++ b/docs/guides/dsm_aws_sobject.md
@@ -38,7 +38,7 @@ resource "dsm_sobject" "aes_sobject" {
   key_ops  = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
 }
 
-# AWS sobject creation(Copies the key from DSM)
+# Create the AWS key by copying the dsm_object as a virtual key in the AWS group
 resource "dsm_aws_sobject" "aws_sobject" {
   name        = "aws_sobject"
   group_id    = dsm_group.aws_group.id
@@ -52,108 +52,84 @@ resource "dsm_aws_sobject" "aws_sobject" {
   }
 }
 
-# 1st Rotation of dsm_sobject
-resource "dsm_sobject" "aes_sobject_rotate1" {
-  name        = "aes_sobject"
-  obj_type    = "AES"
-  group_id    = dsm_group.normal_group.id
-  key_size    = 256
-  key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.aes_sobject.name # Name of the old dsm_sobject
-}
-
 # 1st Rotation of dsm_aws_sobject
 resource "dsm_aws_sobject" "aws_sobject_rotate1" {
-  name        = "aws_sobject"
+  name        = dsm_aws_sobject.aws_sobject.name # Name should be the same as the key name to be rotated.
   group_id    = dsm_group.aws_group.id
   description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
   key = {
-    kid = dsm_sobject.aes_sobject_rotate1.id # 1st Rotated dsm_sbject
+    kid = dsm_sobject.aes_sobject.id
   }
   rotate      = "DSM"
-  rotate_from = dsm_aws_sobject.aws_sobject.name # Name of the old dsm_aws_sobject
-}
-
-
-# 2nd Rotation of dsm_sobject
-resource "dsm_sobject" "aes_sobject_rotate2" {
-  name        = "aes_sobject"
-  obj_type    = "AES"
-  group_id    = dsm_group.normal_group.id
-  key_size    = 256
-  key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.aes_sobject1.name # Name of the old dsm_sobject
+  rotate_from = dsm_aws_sobject.aws_sobject.name # Name of the key from where it is being rotated.
 }
 
 # 2nd Rotation of dsm_aws_sobject
 resource "dsm_aws_sobject" "aws_sobject_rotate2" {
-  name        = "aws_sobject"
+  name        = dsm_aws_sobject.aws_sobject_rotate1.name # Name should be the same as the key name to be rotated.
   group_id    = dsm_group.aws_group.id
   description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
   key = {
-    kid = dsm_sobject.aes_sobject_rotate2.id # 2nd Rotated dsm_sbject
+    kid = dsm_sobject.aes_sobject.id
   }
   rotate      = "DSM"
-  rotate_from = dsm_aws_sobject.aws_sobject_rotate1.name # Name of the old dsm_aws_sobject
+  rotate_from = dsm_aws_sobject.aws_sobject_rotate1.name # Name of the key from where it is being rotated.
 }
 ```
 
 ## Rotate with AWS Option
 
 ```terraform
-# 1st Rotation of dsm_sobject
-resource "dsm_sobject" "aes_sobject_rotate1" {
-  name        = "aes_sobject"
-  obj_type    = "AES"
-  group_id    = dsm_group.normal_group.id
-  key_size    = 256
+# Create a dsm_sobject of type AES key inside DSM
+resource "dsm_sobject" "aes_sobject" {
+  name     = "aes_sobject"
+  obj_type = "AES"
+  group_id = dsm_group.normal_group.id
+  key_size = 256
+  key_ops  = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
+}
+
+# Create the AWS key by copying the dsm_object as a virtual key in the AWS group
+resource "dsm_aws_sobject" "aws_sobject" {
+  name        = "aws_sobject"
+  group_id    = dsm_group.aws_group.id
+  description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.aes_sobject.name # Name of the old dsm_sobject
+  key = {
+    kid = dsm_sobject.aes_sobject.id
+  }
+  custom_metadata = {
+    aws-aliases = "dsm_aws_sobject"
+  }
 }
 
 # 1st Rotation of dsm_aws_sobject
 resource "dsm_aws_sobject" "aws_sobject_rotate1" {
-  name        = "aws_sobject"
+  name        = dsm_aws_sobject.aws_sobject.name # Name should be the same as the key name to be rotated.
   group_id    = dsm_group.aws_group.id
   description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
   key = {
-    kid = dsm_sobject.aes_sobject_rotate1.id # 1st Rotated dsm_sbject
+    kid = dsm_sobject.aes_sobject.id # 1st Rotated dsm_sbject
   }
   rotate      = "AWS"
-  rotate_from = dsm_aws_sobject.aws_sobject.name # Name of the old dsm_aws_sobject
-}
-
-
-# 2nd Rotation of dsm_sobject
-resource "dsm_sobject" "aes_sobject_rotate2" {
-  name        = "aes_sobject"
-  obj_type    = "AES"
-  group_id    = dsm_group.normal_group.id
-  key_size    = 256
-  key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
-  rotate      = "DSM"
-  rotate_from = dsm_sobject.aes_sobject1.name # Name of the old dsm_sobject
+  rotate_from = dsm_aws_sobject.aws_sobject.name # Name of the key from where it is being rotated.
 }
 
 # 2nd Rotation of dsm_aws_sobject
 resource "dsm_aws_sobject" "aws_sobject_rotate2" {
-  name        = "aws_sobject"
+  name        = dsm_aws_sobject.aws_sobject_rotate1.name # Name should be the same as the key name to be rotated.
   group_id    = dsm_group.aws_group.id
   description = "AWS sobject"
   key_ops     = ["EXPORT", "ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "APPMANAGEABLE"]
   key = {
-    kid = dsm_sobject.aes_sobject_rotate2.id # 2nd Rotated dsm_sbject
+    kid = dsm_sobject.aes_sobject.id
   }
   rotate      = "AWS"
-  rotate_from = dsm_aws_sobject.aws_sobject_rotate1.name # Name of the old dsm_aws_sobject
+  rotate_from = dsm_aws_sobject.aws_sobject_rotate1.name # Name of the key from where it is being rotated.
 }
-
 ```
 
 
@@ -210,7 +186,7 @@ resource "dsm_aws_sobject" "dsm_aws_sobject" {
 ## Both schedule_deletion and delete_key_material can be enabled in a single terraform request
 
 ```terraform
-# Enable delete_key_material as true.
+# Enable delete_key_material as true and specify schedule deletion as an Integer. Value should be minimum 7.
 # This can be enabled only during update.
 resource "dsm_aws_sobject" "dsm_aws_sobject" {
   name     = "dsm_aws_sobject"
@@ -223,7 +199,35 @@ resource "dsm_aws_sobject" "dsm_aws_sobject" {
   }
   key_ops = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "EXPORT", "APPMANAGEABLE"]
   # schedule_deletion and delete key material
-  schedule_deletion   = 7
   delete_key_material = true
+  schedule_deletion   = 7
 }
+```
+
+## Example of adding a rotation_policy
+
+```terraform
+# Add interval_months or interval_days. It should be an integer.
+# Add effective_at as a date format.
+# Disable deactivate_rotated_key as it is not supported.
+# deactivate_rotated_key is an optional attribute. Please specify this to to avoid the changes detected during terraform plan.
+
+resource "dsm_aws_sobject" "dsm_aws_sobject" {
+  name     = "dsm_aws_sobject"
+  group_id = dsm_group.dsm_aws_group.id
+  key = {
+    kid = dsm_sobject.dsm_sobject.id
+  }
+  custom_metadata = {
+    aws-aliases = "dsm_aws_sobject"
+  }
+  key_ops = ["ENCRYPT", "DECRYPT", "WRAPKEY", "UNWRAPKEY", "DERIVEKEY", "MACGENERATE", "MACVERIFY", "EXPORT", "APPMANAGEABLE"]
+  rotation_policy = {
+    interval_months        = 7
+    effective_at           = "20260730T230000Z"
+    deactivate_rotated_key = false
+  }
+}
+```
+
 ```

--- a/docs/resources/aws_sobject.md
+++ b/docs/resources/aws_sobject.md
@@ -9,7 +9,8 @@ description: |-
   Note: Once scheduled deletion is enabled, AWS security object can't be modified.
   Deletion of a dsm_aws_sobject: Unlike dsm_sobject, deletion of a dsm_aws_sobject is not normal.
   Steps to delete a dsm_azure_sobject:
-  Enable schedule_deletion as shown in the examples of guides/dsm_azure_sobject.Enable delete_key_material as shown in the examples of guides/dsm_azure_sobject.A dsm_aws_sobject can be deleted completely only when its state is destroyed.A dsm_aws_sobject is destroyed when the key is deleted from Azure key vault.To know whether it is in a destroyed state or not, sync keys operation should be performed.Use dsm_aws_group data_source to sync the keys. Please refer Data Sources/dsm_aws_group.
+  Enable delete_key_material as shown in the examples of Guides/dsm_aws_sobject.Enable schedule_deletion as shown in the examples of Guides/dsm_aws_sobject.A dsm_aws_sobject can be deleted completely only when its state is destroyed.A dsm_aws_sobject comes to destroyed state when the key is deleted from AWS KMS.To know whether it is in a destroyed state or not, sync keys operation should be performed.Use dsm_aws_group data_source to sync the keys. Please refer Data Sources/dsm_aws_group.
+  Note: delete_key_material can be skipped if schedule_deletion is enabled as it deletes the key material as well.
 ---
 
 # dsm_aws_sobject (Resource)
@@ -24,12 +25,14 @@ AWS security object can also rotate and enable scheduled deletion. For more exam
 **Deletion of a dsm_aws_sobject**: Unlike dsm_sobject, deletion of a dsm_aws_sobject is not normal.
 
 **Steps to delete a dsm_azure_sobject:**
-   * Enable schedule_deletion as shown in the examples of guides/dsm_azure_sobject.
-   * Enable delete_key_material as shown in the examples of guides/dsm_azure_sobject.
+   * Enable `delete_key_material` as shown in the examples of `Guides/dsm_aws_sobject`.
+   * Enable `schedule_deletion` as shown in the examples of `Guides/dsm_aws_sobject`.
    * A dsm_aws_sobject can be deleted completely only when its state is `destroyed`.
-   * A dsm_aws_sobject is destroyed when the key is deleted from Azure key vault.
+   * A dsm_aws_sobject comes to destroyed state when the key is deleted from AWS KMS.
    * To know whether it is in a destroyed state or not, sync keys operation should be performed.
-   * Use dsm_aws_group data_source to sync the keys. Please refer Data Sources/dsm_aws_group.
+   * Use `dsm_aws_group` data_source to sync the keys. Please refer `Data Sources/dsm_aws_group`.
+
+**Note**: `delete_key_material` can be skipped if `schedule_deletion` is enabled as it deletes the key material as well.
 
 ## Example Usage
 

--- a/docs/resources/aws_sobject.md
+++ b/docs/resources/aws_sobject.md
@@ -9,7 +9,7 @@ description: |-
   Note: Once scheduled deletion is enabled, AWS security object can't be modified.
   Deletion of a dsm_aws_sobject: Unlike dsm_sobject, deletion of a dsm_aws_sobject is not normal.
   Steps to delete a dsm_azure_sobject:
-  Enable schedule_deletion as shown in the examples of guides/dsm_azure_sobject.Enable delete_key_material as shown in the examples of guides/dsm_azure_sobject.A dsm_aws_sobject can be deleted completely only when its state is destroyed.A dsm_aws_sobject is destroyed when the key is deleted from Azure key vault.To know whether it is in a destroyed state or not, sync keys operation should be performed.Currently, sync keys is not supported by terraform. This can be done in UI by going to the group and HSM/KMS. Then click on SYNC KEYS.
+  Enable schedule_deletion as shown in the examples of guides/dsm_azure_sobject.Enable delete_key_material as shown in the examples of guides/dsm_azure_sobject.A dsm_aws_sobject can be deleted completely only when its state is destroyed.A dsm_aws_sobject is destroyed when the key is deleted from Azure key vault.To know whether it is in a destroyed state or not, sync keys operation should be performed.Use dsm_aws_group data_source to sync the keys. Please refer Data Sources/dsm_aws_group.
 ---
 
 # dsm_aws_sobject (Resource)
@@ -29,7 +29,7 @@ AWS security object can also rotate and enable scheduled deletion. For more exam
    * A dsm_aws_sobject can be deleted completely only when its state is `destroyed`.
    * A dsm_aws_sobject is destroyed when the key is deleted from Azure key vault.
    * To know whether it is in a destroyed state or not, sync keys operation should be performed.
-   * Currently, sync keys is not supported by terraform. This can be done in UI by going to the group and HSM/KMS. Then click on `SYNC KEYS`.
+   * Use dsm_aws_group data_source to sync the keys. Please refer Data Sources/dsm_aws_group.
 
 ## Example Usage
 

--- a/docs/resources/aws_sobject.md
+++ b/docs/resources/aws_sobject.md
@@ -169,7 +169,9 @@ resource "dsm_aws_sobject" "aws_sobject_temp_creds" {
    * `aws-aliases`: Key name within AWS KMS.
    * `aws-policy`: JSON format of AWS policy that should be enforced for the key.
    * **Note:** Any other DSM custom metadata can be configured.
-- `delete_key_material` (Boolean) Delete key material in AWS KMS. Deleting key material makes all data encrypted under the customer master key (CMK) unrecoverable unless you later import the same key material from DSM into the CMK.The DSM source key is not affected by this operation. The supported values are true/false.**Note:** This can enabled only after creation.
+- `delete_key_material` (Boolean) Delete key material in AWS KMS. Deleting key material makes all data encrypted under the customer master key (CMK) unrecoverable unless you later import the same key material from DSM into the CMK.The DSM source key is not affected by this operation. The supported values are true/false.
+
+**Note:** This can enabled only after creation.
 - `description` (String) The security object description.
 - `enabled` (Boolean) Whether the security object will be enabled or disabled. The supported values are true/false.
 - `expiry_date` (String) The security object expiry date in RFC format.
@@ -188,7 +190,9 @@ resource "dsm_aws_sobject" "aws_sobject_temp_creds" {
    * `interval_days`: Rotate the key for every given number of days.
    * `interval_months`: Rotate the key for every given number of months.
    * `effective_at`: Start of the rotation policy time.
+   * `deactivate_rotated_key`: This is not supported. Please provide `false` to avoid the changes detected during terraform plan.
    * **Note:** Either interval_days or interval_months should be given, but not both.
+   * **Note:** Please refer Guides/dsm_aws_sobject for an example.
 - `schedule_deletion` (Number) Schedule key deletion in AWS KMS. Key is not usable for Sign/Verify, Wrap/Unwrap or Encrypt/Decrypt operations once it is deleted. Minimum value is 7 days.
 **Note:** This can enabled only after creation.
 - `state` (String) The key states of the AWS key. The supported values are PendingDeletion, Enabled, Disabled and PendingImport.
@@ -200,7 +204,7 @@ resource "dsm_aws_sobject" "aws_sobject_temp_creds" {
 - `copied_to` (List of String) List of security objects copied by the current security object.
 - `creator` (Map of String) The creator of the group from Fortanix DSM.
    * `user`: If the group was created by a user, the computed value will be the matching user id.
-   * `app`: If the group was created by a app, the computed value will be the matching app id.
+   * `app`: If the group was created by an app, the computed value will be the matching app id.
 - `dsm_name` (String) The security object name from Fortanix DSM (matches the name provided during creation).
 - `external` (Map of String) AWS CMK level metadata:
    * `Key_arn`

--- a/docs/resources/aws_sobject.md
+++ b/docs/resources/aws_sobject.md
@@ -9,7 +9,7 @@ description: |-
   Note: Once scheduled deletion is enabled, AWS security object can't be modified.
   Deletion of a dsm_aws_sobject: Unlike dsm_sobject, deletion of a dsm_aws_sobject is not normal.
   Steps to delete a dsm_azure_sobject:
-  Enable delete_key_material as shown in the examples of Guides/dsm_aws_sobject.Enable schedule_deletion as shown in the examples of Guides/dsm_aws_sobject.A dsm_aws_sobject can be deleted completely only when its state is destroyed.A dsm_aws_sobject comes to destroyed state when the key is deleted from AWS KMS.To know whether it is in a destroyed state or not, sync keys operation should be performed.Use dsm_aws_group data_source to sync the keys. Please refer Data Sources/dsm_aws_group.
+  Enable delete_key_material as shown in the examples of Guides/dsm_aws_sobject.Enable schedule_deletion as shown in the examples of Guides/dsm_aws_sobject.A dsm_aws_sobject can be deleted completely only when its state is destroyed.A dsm_aws_sobject's state is destroyed when the key is deleted from AWS KMS.To know whether it is in a destroyed state or not, sync keys operation should be performed.Use dsm_aws_group data_source to sync the keys. Please refer Data Sources/dsm_aws_group.
   Note: delete_key_material can be skipped if schedule_deletion is enabled as it deletes the key material as well.
 ---
 
@@ -28,7 +28,7 @@ AWS security object can also rotate and enable scheduled deletion. For more exam
    * Enable `delete_key_material` as shown in the examples of `Guides/dsm_aws_sobject`.
    * Enable `schedule_deletion` as shown in the examples of `Guides/dsm_aws_sobject`.
    * A dsm_aws_sobject can be deleted completely only when its state is `destroyed`.
-   * A dsm_aws_sobject comes to destroyed state when the key is deleted from AWS KMS.
+   * A dsm_aws_sobject's state is destroyed when the key is deleted from AWS KMS.
    * To know whether it is in a destroyed state or not, sync keys operation should be performed.
    * Use `dsm_aws_group` data_source to sync the keys. Please refer `Data Sources/dsm_aws_group`.
 
@@ -193,7 +193,6 @@ resource "dsm_aws_sobject" "aws_sobject_temp_creds" {
    * `interval_days`: Rotate the key for every given number of days.
    * `interval_months`: Rotate the key for every given number of months.
    * `effective_at`: Start of the rotation policy time.
-   * `deactivate_rotated_key`: This is not supported. Please provide `false` to avoid the changes detected during terraform plan.
    * **Note:** Either interval_days or interval_months should be given, but not both.
    * **Note:** Please refer Guides/dsm_aws_sobject for an example.
 - `schedule_deletion` (Number) Schedule key deletion in AWS KMS. Key is not usable for Sign/Verify, Wrap/Unwrap or Encrypt/Decrypt operations once it is deleted. Minimum value is 7 days.

--- a/dsm/resource_aws_sobject.go
+++ b/dsm/resource_aws_sobject.go
@@ -41,12 +41,13 @@ func resourceAWSSobject() *schema.Resource {
 		"**Note**: Once scheduled deletion is enabled, AWS security object can't be modified.\n\n" +
 		"**Deletion of a dsm_aws_sobject**: Unlike dsm_sobject, deletion of a dsm_aws_sobject is not normal.\n\n" +
 		"**Steps to delete a dsm_azure_sobject:**\n" +
-		"   * Enable schedule_deletion as shown in the examples of guides/dsm_azure_sobject.\n" +
-		"   * Enable delete_key_material as shown in the examples of guides/dsm_azure_sobject.\n" +
+		"   * Enable `delete_key_material` as shown in the examples of `Guides/dsm_aws_sobject`.\n" +
+		"   * Enable `schedule_deletion` as shown in the examples of `Guides/dsm_aws_sobject`.\n" +
 		"   * A dsm_aws_sobject can be deleted completely only when its state is `destroyed`.\n" +
-		"   * A dsm_aws_sobject is destroyed when the key is deleted from Azure key vault.\n" +
+		"   * A dsm_aws_sobject comes to destroyed state when the key is deleted from AWS KMS.\n" +
 		"   * To know whether it is in a destroyed state or not, sync keys operation should be performed.\n" +
-		"   * Use dsm_aws_group data_source to sync the keys. Please refer Data Sources/dsm_aws_group.",
+		"   * Use `dsm_aws_group` data_source to sync the keys. Please refer `Data Sources/dsm_aws_group`.\n\n" +
+		"**Note**: `delete_key_material` can be skipped if `schedule_deletion` is enabled as it deletes the key material as well.",
 		Schema: map[string]*schema.Schema{
 			"name": {
 			    Description: "The security object name.",

--- a/dsm/resource_aws_sobject.go
+++ b/dsm/resource_aws_sobject.go
@@ -107,7 +107,7 @@ func resourceAWSSobject() *schema.Resource {
 			"creator": {
 				Description: "The creator of the group from Fortanix DSM.\n" +
 				"   * `user`: If the group was created by a user, the computed value will be the matching user id.\n" +
-				"   * `app`: If the group was created by a app, the computed value will be the matching app id.",
+				"   * `app`: If the group was created by an app, the computed value will be the matching app id.",
 				Type:     schema.TypeMap,
 				Computed: true,
 				Elem: &schema.Schema{
@@ -119,7 +119,9 @@ func resourceAWSSobject() *schema.Resource {
 				"   * `interval_days`: Rotate the key for every given number of days.\n" +
 				"   * `interval_months`: Rotate the key for every given number of months.\n" +
 				"   * `effective_at`: Start of the rotation policy time.\n" +
-				"   * **Note:** Either interval_days or interval_months should be given, but not both.",
+				"   * `deactivate_rotated_key`: This is not supported. Please provide `false` to avoid the changes detected during terraform plan.\n" +
+				"   * **Note:** Either interval_days or interval_months should be given, but not both.\n" +
+				"   * **Note:** Please refer Guides/dsm_aws_sobject for an example.",
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem: &schema.Schema{
@@ -230,11 +232,10 @@ func resourceAWSSobject() *schema.Resource {
 			},
 			"delete_key_material": {
 				Description: "Delete key material in AWS KMS. Deleting key material makes all data encrypted under the customer master key (CMK) unrecoverable unless you later import the same key material from DSM into the CMK." +
-				"The DSM source key is not affected by this operation. The supported values are true/false." +
+				"The DSM source key is not affected by this operation. The supported values are true/false.\n\n" +
 				"**Note:** This can enabled only after creation.",
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 		},
 		Importer: &schema.ResourceImporter{
@@ -470,6 +471,27 @@ func resourceUpdateAWSSobject(ctx context.Context, d *schema.ResourceData, m int
     if d.HasChange("key") {
         return undoTFstate("key", d)
     }
+	if d.HasChange("delete_key_material") && d.Get("delete_key_material").(bool){
+		current_key_state := d.Get("external").(map[string]interface{})["Key_state"]
+		if current_key_state != "PendingDeletion" && current_key_state != "PendingImport"{
+			err := deleteKeyMateialBYOKSobject(d, m)
+			if err != nil {
+				d.Set("delete_key_material", nil)
+				// When delete_key_material fails and schedule_deletion is enabled, then schedule_deletion needs to revert
+				// as it will not be invoked.
+				if d.HasChange("schedule_deletion") {
+					d.Set("schedule_deletion", nil)
+				}
+				return err
+			}
+			if !d.HasChange("schedule_deletion") {
+				return resourceReadAWSSobject(ctx, d, m)
+			}
+		} else {
+			// If the state is already in PendingDeletion or PendingImport, then no need to invoke delete_key_material API and show a warning.
+			return showWarning(fmt.Sprintf("The security object is in the state of %s. delete_key_material cannot be applied.", current_key_state))
+		}
+	}
 	if d.HasChange("schedule_deletion") {
 		if pending_window_in_days := d.Get("schedule_deletion").(int); pending_window_in_days > 6 {
 			schedule_deletion := map[string]interface{}{
@@ -481,21 +503,12 @@ func resourceUpdateAWSSobject(ctx context.Context, d *schema.ResourceData, m int
 					d.Set("schedule_deletion", nil)
 					return invokeErrorDiagsWithSummary(error_summary, fmt.Sprintf("[E]: API: POST crypto/v1/keys/%s/schedule_deletion, %v", d.Id(), err))
 				}
+				return resourceReadAWSSobject(ctx, d, m)
 			} else {
+			    // If the state is already in PendingDeletion, then no need to invoke schedule_deletion API and show a warning.
 				return showWarning("The security object is already scheduled for the deletion.")
 			}
-			if !(d.HasChange("delete_key_material") && d.Get("delete_key_material").(bool)){
-				return resourceReadAWSSobject(ctx, d, m)
-			}
 		}
-	}
-	if d.HasChange("delete_key_material") && d.Get("delete_key_material").(bool){
-		err := deleteKeyMateialBYOKSobject(d, m)
-		if err != nil {
-			d.Set("delete_key_material", false)
-			return err
-		}
-		return resourceReadAWSSobject(ctx, d, m)
 	}
 	// already has been replaced so "rotate" and "rotate_from" does not apply
 	_, replacement := d.GetOk("replacement")

--- a/dsm/resource_aws_sobject.go
+++ b/dsm/resource_aws_sobject.go
@@ -46,7 +46,7 @@ func resourceAWSSobject() *schema.Resource {
 		"   * A dsm_aws_sobject can be deleted completely only when its state is `destroyed`.\n" +
 		"   * A dsm_aws_sobject is destroyed when the key is deleted from Azure key vault.\n" +
 		"   * To know whether it is in a destroyed state or not, sync keys operation should be performed.\n" +
-		"   * Currently, sync keys is not supported by terraform. This can be done in UI by going to the group and HSM/KMS. Then click on `SYNC KEYS`.",
+		"   * Use dsm_aws_group data_source to sync the keys. Please refer Data Sources/dsm_aws_group.",
 		Schema: map[string]*schema.Schema{
 			"name": {
 			    Description: "The security object name.",

--- a/dsm/resource_aws_sobject.go
+++ b/dsm/resource_aws_sobject.go
@@ -44,7 +44,7 @@ func resourceAWSSobject() *schema.Resource {
 		"   * Enable `delete_key_material` as shown in the examples of `Guides/dsm_aws_sobject`.\n" +
 		"   * Enable `schedule_deletion` as shown in the examples of `Guides/dsm_aws_sobject`.\n" +
 		"   * A dsm_aws_sobject can be deleted completely only when its state is `destroyed`.\n" +
-		"   * A dsm_aws_sobject comes to destroyed state when the key is deleted from AWS KMS.\n" +
+		"   * A dsm_aws_sobject's state is destroyed when the key is deleted from AWS KMS.\n" +
 		"   * To know whether it is in a destroyed state or not, sync keys operation should be performed.\n" +
 		"   * Use `dsm_aws_group` data_source to sync the keys. Please refer `Data Sources/dsm_aws_group`.\n\n" +
 		"**Note**: `delete_key_material` can be skipped if `schedule_deletion` is enabled as it deletes the key material as well.",
@@ -120,7 +120,6 @@ func resourceAWSSobject() *schema.Resource {
 				"   * `interval_days`: Rotate the key for every given number of days.\n" +
 				"   * `interval_months`: Rotate the key for every given number of months.\n" +
 				"   * `effective_at`: Start of the rotation policy time.\n" +
-				"   * `deactivate_rotated_key`: This is not supported. Please provide `false` to avoid the changes detected during terraform plan.\n" +
 				"   * **Note:** Either interval_days or interval_months should be given, but not both.\n" +
 				"   * **Note:** Please refer Guides/dsm_aws_sobject for an example.",
 				Type:     schema.TypeMap,
@@ -454,6 +453,9 @@ func resourceReadAWSSobject(ctx context.Context, d *schema.ResourceData, m inter
 		}
 		if _, ok := req["rotation_policy"]; ok {
 			rotation_policy := sobj_rotation_policy_read(req["rotation_policy"].(map[string]interface{}))
+			if _, ok := rotation_policy["deactivate_rotated_key"]; ok {
+				delete(rotation_policy, "deactivate_rotated_key")
+			}
 			if err := d.Set("rotation_policy", rotation_policy); err != nil {
 				return diag.FromErr(err)
 			}


### PR DESCRIPTION
Fixed PROD-9286

Issue:
1. when both delete_key_material and schedule_deletion are enabled, then it should first invoke delete_key_material and then schedule_deletion.
2. Also, added warnings whereever it is necessary.
3. Added the doc changes for rotation_policy.

 On branch PROD-9286
 Changes to be committed:
	modified:   docs-archived/guides/dsm_aws_sobject.md
	modified:   docs/guides/dsm_aws_sobject.md
	modified:   docs/resources/aws_sobject.md
	modified:   dsm/resource_aws_sobject.go